### PR TITLE
Improve Fedora install scripts: cargo/npm fallbacks and robustness

### DIFF
--- a/scripts-fedora/assets/install-dev-tools.sh
+++ b/scripts-fedora/assets/install-dev-tools.sh
@@ -5,7 +5,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../lib/utils.sh"
 
 main() {
     info "Instalando ferramentas de desenvolvimento (equivalente ao base-devel)"
-    ensure_group "Development Tools"
+    ensure_group "development-tools"
     ensure_package "gcc-c++"
     ensure_package "make"
     ensure_package "automake"

--- a/scripts-fedora/assets/install-eza.sh
+++ b/scripts-fedora/assets/install-eza.sh
@@ -5,7 +5,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../lib/utils.sh"
 
 main() {
     info "Instalando eza"
-    ensure_package "eza"
+    ensure_cargo_package "eza"
 }
 
 main "$@"

--- a/scripts-fedora/assets/install-fonts.sh
+++ b/scripts-fedora/assets/install-fonts.sh
@@ -9,12 +9,12 @@ main() {
     # Fontes disponiveis nos repos oficiais do Fedora
     packages=(
         "fira-code-fonts"
+        "fira-mono-fonts"
         "jetbrains-mono-fonts-all"
         "google-noto-fonts-common"
         "google-noto-emoji-fonts"
         "google-noto-sans-fonts"
         "google-noto-serif-fonts"
-        "mozilla-fira-mono-fonts"
     )
 
     for pkg in "${packages[@]}"; do

--- a/scripts-fedora/assets/install-hyprland-autostart.sh
+++ b/scripts-fedora/assets/install-hyprland-autostart.sh
@@ -13,13 +13,14 @@ main() {
 
     if [ ! -f "$HYPRLAND_CONFIG" ]; then
         warn "Configuracao do Hyprland nao encontrada em $HYPRLAND_CONFIG"
-        warn "Por favor, instale o Hyprland primeiro"
-        return 1
+        warn "Pulando autostart (opcional)."
+        return 0
     fi
 
     if [ ! -f "$OVERRIDES_CONFIG" ]; then
         warn "Arquivo de autostart nao encontrado em $OVERRIDES_CONFIG"
-        return 1
+        warn "Pulando autostart (opcional)."
+        return 0
     fi
 
     if grep -Fxq "$SOURCE_LINE" "$HYPRLAND_CONFIG"; then

--- a/scripts-fedora/assets/install-hyprland-overrides.sh
+++ b/scripts-fedora/assets/install-hyprland-overrides.sh
@@ -13,13 +13,14 @@ main() {
 
     if [ ! -f "$HYPRLAND_CONFIG" ]; then
         warn "Configuracao do Hyprland nao encontrada em $HYPRLAND_CONFIG"
-        warn "Por favor, instale o Hyprland primeiro"
-        return 1
+        warn "Pulando overrides (opcional)."
+        return 0
     fi
 
     if [ ! -f "$OVERRIDES_CONFIG" ]; then
         warn "Arquivo de overrides nao encontrado em $OVERRIDES_CONFIG"
-        return 1
+        warn "Pulando overrides (opcional)."
+        return 0
     fi
 
     if grep -Fxq "$SOURCE_LINE" "$HYPRLAND_CONFIG"; then

--- a/scripts-fedora/assets/install-lib32-libs.sh
+++ b/scripts-fedora/assets/install-lib32-libs.sh
@@ -14,16 +14,23 @@ main() {
         "mesa-vulkan-drivers.i686"
         "vulkan-loader.i686"
         "alsa-lib.i686"
-        "pulseaudio-libs.i686"
         "gnutls.i686"
         "libXcomposite.i686"
         "libXinerama.i686"
-        "opencl-utils.i686"
-        "SDL2.i686"
     )
 
     for pkg in "${packages[@]}"; do
         ensure_package "$pkg"
+    done
+
+    optional_packages=(
+        "pulseaudio-libs.i686"
+        "opencl-utils.i686"
+        "SDL2.i686"
+    )
+
+    for pkg in "${optional_packages[@]}"; do
+        ensure_package "$pkg" || warn "Pacote opcional '$pkg' nao encontrado."
     done
 
     ok "Bibliotecas 32-bit instaladas."

--- a/scripts-fedora/assets/install-lsps.sh
+++ b/scripts-fedora/assets/install-lsps.sh
@@ -11,12 +11,13 @@ main() {
         "shfmt"
         "ripgrep"
         "fd-find"
-        "prettier"
     )
 
     for pkg in "${packages[@]}"; do
         ensure_package "$pkg"
     done
+
+    ensure_npm_global "prettier" "prettier"
 
     # Ruff pode nao estar nos repos oficiais
     ensure_package "ruff" || {

--- a/scripts-fedora/assets/install-postgresql.sh
+++ b/scripts-fedora/assets/install-postgresql.sh
@@ -19,15 +19,24 @@ main() {
     # No Fedora, usa-se postgresql-setup para inicializar
     if [ ! -d "/var/lib/pgsql/data" ] || [ -z "$(ls -A /var/lib/pgsql/data 2>/dev/null)" ]; then
         info "Inicializando banco de dados PostgreSQL..."
-        sudo postgresql-setup --initdb
+        if ! sudo postgresql-setup --initdb >> "$LOG_FILE" 2>&1; then
+            fail "Falha ao inicializar o PostgreSQL. Verifique o log: $LOG_FILE"
+            return 1
+        fi
     else
         info "Diretorio de dados do PostgreSQL ja inicializado, pulando..."
     fi
 
     # Inicia e habilita o servico
     info "Iniciando servico PostgreSQL..."
-    sudo systemctl start postgresql
-    sudo systemctl enable postgresql
+    if ! sudo systemctl start postgresql >> "$LOG_FILE" 2>&1; then
+        fail "Falha ao iniciar o PostgreSQL. Verifique o log: $LOG_FILE"
+        return 1
+    fi
+    if ! sudo systemctl enable postgresql >> "$LOG_FILE" 2>&1; then
+        fail "Falha ao habilitar o PostgreSQL. Verifique o log: $LOG_FILE"
+        return 1
+    fi
 
     # Aguarda PostgreSQL ficar pronto
     sleep 2
@@ -35,7 +44,10 @@ main() {
     # Cria usuario PostgreSQL correspondente ao usuario atual
     info "Configurando usuario PostgreSQL..."
     if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_user WHERE usename='$USER'" | grep -q 1; then
-        sudo -u postgres createuser --interactive -d "$USER"
+        if ! sudo -u postgres createuser --interactive -d "$USER" >> "$LOG_FILE" 2>&1; then
+            fail "Falha ao criar usuario PostgreSQL. Verifique o log: $LOG_FILE"
+            return 1
+        fi
         ok "Usuario PostgreSQL criado: $USER"
     else
         ok "Usuario PostgreSQL $USER ja existe"
@@ -43,7 +55,10 @@ main() {
 
     # Cria banco de dados padrao
     if ! sudo -u postgres psql -lqt | cut -d \| -f 1 | grep -qw "$USER"; then
-        createdb "$USER"
+        if ! createdb "$USER" >> "$LOG_FILE" 2>&1; then
+            fail "Falha ao criar banco de dados. Verifique o log: $LOG_FILE"
+            return 1
+        fi
         ok "Banco de dados padrao criado: $USER"
     else
         ok "Banco de dados $USER ja existe"

--- a/scripts-fedora/assets/install-ruby.sh
+++ b/scripts-fedora/assets/install-ruby.sh
@@ -12,8 +12,8 @@ main() {
     fi
 
     if ! command -v asdf &>/dev/null; then
-        fail "asdf nao esta instalado. Por favor, execute install-asdf.sh primeiro."
-        exit 1
+        warn "asdf nao esta instalado. Execute install-asdf.sh se quiser instalar Ruby via asdf."
+        return 0
     fi
 
     # Instala dependencias de build do Ruby (Fedora)

--- a/scripts-fedora/assets/install-vulkan-stack.sh
+++ b/scripts-fedora/assets/install-vulkan-stack.sh
@@ -10,12 +10,13 @@ main() {
         "vulkan-loader"
         "vulkan-tools"
         "vulkan-validation-layers"
-        "vkd3d"
     )
 
     for pkg in "${packages[@]}"; do
         ensure_package "$pkg"
     done
+
+    ensure_package "vkd3d" || warn "vkd3d nao encontrado nos repos (opcional)."
 
     ok "Vulkan stack instalada."
 }

--- a/scripts-fedora/assets/install-yazi-deps.sh
+++ b/scripts-fedora/assets/install-yazi-deps.sh
@@ -6,6 +6,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/../lib/utils.sh"
 main() {
     info "Instalando dependencias para Yazi"
 
+    ensure_rpmfusion
+
     packages=(
         "ffmpeg"
         "p7zip"


### PR DESCRIPTION
### Motivation
- Fix recurring installation failures when migrating packages from Arch to Fedora by adding fallbacks for missing packages and repos. 
- Ensure common developer tools (`eza`, `prettier`, `ffmpeg`, etc.) install reliably even when not available in DNF. 
- Make optional desktop/config steps (Hyprland overrides/autostart) non-fatal so `install-all.sh` can continue. 
- Improve error handling and logging for services that require initialization (PostgreSQL) and for group detection. 

### Description
- Added `ensure_cargo_package` and `ensure_npm_global` helpers to `lib/utils.sh` to install Rust/Cargo binaries and global `npm` packages respectively, and tightened DNF group detection by using `dnf group list --installed --ids`. 
- Switched `install-eza.sh` to use `ensure_cargo_package` for `eza` and updated `install-lsps.sh` to install `prettier` via `ensure_npm_global`. 
- Updated `install-yazi-deps.sh` to call `ensure_rpmfusion` before installing `ffmpeg` and related packages. 
- Fixed `install-dev-tools.sh` to use the correct DNF group name `development-tools`. 
- Adjusted `install-fonts.sh` to use `fira-mono-fonts` and removed a non-existent `mozilla-fira-mono-fonts`, and kept Nerd Fonts via COPR. 
- Made `vkd3d` optional in `install-vulkan-stack.sh` with a warning if missing. 
- Moved some 32-bit packages to an `optional_packages` list in `install-lib32-libs.sh` and warn instead of failing if they are absent. 
- Made `install-ruby.sh` non-fatal when `asdf` is not present by warning and returning early instead of exiting with failure. 
- Hardened `install-postgresql.sh` with redirected logging and error checks for `postgresql-setup`, `systemctl` operations, `createuser`, and `createdb`, returning on failure and logging to `LOG_FILE`. 
- Made `install-hyprland-overrides.sh` and `install-hyprland-autostart.sh` skip with a warning (return `0`) when expected config files are not present so they are optional. 

### Testing
- No automated tests were run for these script-only edits; changes were validated by code review and committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69872be4380483308b85bfb5c16e8244)