### PR TITLE
Improve Fedora installers: short-circuit PostgreSQL, optional packages, and cargo/npm helpers

### DIFF
--- a/scripts-fedora/assets/install-dev-tools.sh
+++ b/scripts-fedora/assets/install-dev-tools.sh
@@ -5,7 +5,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../lib/utils.sh"
 
 main() {
     info "Instalando ferramentas de desenvolvimento (equivalente ao base-devel)"
-    ensure_group "Development Tools"
+    ensure_group "development-tools"
     ensure_package "gcc-c++"
     ensure_package "make"
     ensure_package "automake"

--- a/scripts-fedora/assets/install-eza.sh
+++ b/scripts-fedora/assets/install-eza.sh
@@ -5,7 +5,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../lib/utils.sh"
 
 main() {
     info "Instalando eza"
-    ensure_package "eza"
+    ensure_cargo_package "eza"
 }
 
 main "$@"

--- a/scripts-fedora/assets/install-fonts.sh
+++ b/scripts-fedora/assets/install-fonts.sh
@@ -9,12 +9,12 @@ main() {
     # Fontes disponiveis nos repos oficiais do Fedora
     packages=(
         "fira-code-fonts"
+        "fira-mono-fonts"
         "jetbrains-mono-fonts-all"
         "google-noto-fonts-common"
         "google-noto-emoji-fonts"
         "google-noto-sans-fonts"
         "google-noto-serif-fonts"
-        "mozilla-fira-mono-fonts"
     )
 
     for pkg in "${packages[@]}"; do

--- a/scripts-fedora/assets/install-hyprland-autostart.sh
+++ b/scripts-fedora/assets/install-hyprland-autostart.sh
@@ -13,13 +13,14 @@ main() {
 
     if [ ! -f "$HYPRLAND_CONFIG" ]; then
         warn "Configuracao do Hyprland nao encontrada em $HYPRLAND_CONFIG"
-        warn "Por favor, instale o Hyprland primeiro"
-        return 1
+        warn "Pulando autostart (opcional)."
+        return 0
     fi
 
     if [ ! -f "$OVERRIDES_CONFIG" ]; then
         warn "Arquivo de autostart nao encontrado em $OVERRIDES_CONFIG"
-        return 1
+        warn "Pulando autostart (opcional)."
+        return 0
     fi
 
     if grep -Fxq "$SOURCE_LINE" "$HYPRLAND_CONFIG"; then

--- a/scripts-fedora/assets/install-hyprland-overrides.sh
+++ b/scripts-fedora/assets/install-hyprland-overrides.sh
@@ -13,13 +13,14 @@ main() {
 
     if [ ! -f "$HYPRLAND_CONFIG" ]; then
         warn "Configuracao do Hyprland nao encontrada em $HYPRLAND_CONFIG"
-        warn "Por favor, instale o Hyprland primeiro"
-        return 1
+        warn "Pulando overrides (opcional)."
+        return 0
     fi
 
     if [ ! -f "$OVERRIDES_CONFIG" ]; then
         warn "Arquivo de overrides nao encontrado em $OVERRIDES_CONFIG"
-        return 1
+        warn "Pulando overrides (opcional)."
+        return 0
     fi
 
     if grep -Fxq "$SOURCE_LINE" "$HYPRLAND_CONFIG"; then

--- a/scripts-fedora/assets/install-lib32-libs.sh
+++ b/scripts-fedora/assets/install-lib32-libs.sh
@@ -14,16 +14,23 @@ main() {
         "mesa-vulkan-drivers.i686"
         "vulkan-loader.i686"
         "alsa-lib.i686"
-        "pulseaudio-libs.i686"
         "gnutls.i686"
         "libXcomposite.i686"
         "libXinerama.i686"
-        "opencl-utils.i686"
-        "SDL2.i686"
     )
 
     for pkg in "${packages[@]}"; do
         ensure_package "$pkg"
+    done
+
+    optional_packages=(
+        "pulseaudio-libs.i686"
+        "opencl-utils.i686"
+        "SDL2.i686"
+    )
+
+    for pkg in "${optional_packages[@]}"; do
+        ensure_package "$pkg" || warn "Pacote opcional '$pkg' nao encontrado."
     done
 
     ok "Bibliotecas 32-bit instaladas."

--- a/scripts-fedora/assets/install-lsps.sh
+++ b/scripts-fedora/assets/install-lsps.sh
@@ -11,12 +11,13 @@ main() {
         "shfmt"
         "ripgrep"
         "fd-find"
-        "prettier"
     )
 
     for pkg in "${packages[@]}"; do
         ensure_package "$pkg"
     done
+
+    ensure_npm_global "prettier" "prettier"
 
     # Ruff pode nao estar nos repos oficiais
     ensure_package "ruff" || {

--- a/scripts-fedora/assets/install-postgresql.sh
+++ b/scripts-fedora/assets/install-postgresql.sh
@@ -6,6 +6,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/../lib/utils.sh"
 main() {
     info "Instalando PostgreSQL..."
 
+    if rpm -q postgresql postgresql-server postgresql-contrib &>/dev/null; then
+        ok "PostgreSQL ja instalado. Pulando instalacao."
+        return 0
+    fi
+
     packages=(
         "postgresql"
         "postgresql-server"
@@ -19,15 +24,24 @@ main() {
     # No Fedora, usa-se postgresql-setup para inicializar
     if [ ! -d "/var/lib/pgsql/data" ] || [ -z "$(ls -A /var/lib/pgsql/data 2>/dev/null)" ]; then
         info "Inicializando banco de dados PostgreSQL..."
-        sudo postgresql-setup --initdb
+        if ! sudo postgresql-setup --initdb >> "$LOG_FILE" 2>&1; then
+            fail "Falha ao inicializar o PostgreSQL. Verifique o log: $LOG_FILE"
+            return 1
+        fi
     else
         info "Diretorio de dados do PostgreSQL ja inicializado, pulando..."
     fi
 
     # Inicia e habilita o servico
     info "Iniciando servico PostgreSQL..."
-    sudo systemctl start postgresql
-    sudo systemctl enable postgresql
+    if ! sudo systemctl start postgresql >> "$LOG_FILE" 2>&1; then
+        fail "Falha ao iniciar o PostgreSQL. Verifique o log: $LOG_FILE"
+        return 1
+    fi
+    if ! sudo systemctl enable postgresql >> "$LOG_FILE" 2>&1; then
+        fail "Falha ao habilitar o PostgreSQL. Verifique o log: $LOG_FILE"
+        return 1
+    fi
 
     # Aguarda PostgreSQL ficar pronto
     sleep 2
@@ -35,7 +49,10 @@ main() {
     # Cria usuario PostgreSQL correspondente ao usuario atual
     info "Configurando usuario PostgreSQL..."
     if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_user WHERE usename='$USER'" | grep -q 1; then
-        sudo -u postgres createuser --interactive -d "$USER"
+        if ! sudo -u postgres createuser --interactive -d "$USER" >> "$LOG_FILE" 2>&1; then
+            fail "Falha ao criar usuario PostgreSQL. Verifique o log: $LOG_FILE"
+            return 1
+        fi
         ok "Usuario PostgreSQL criado: $USER"
     else
         ok "Usuario PostgreSQL $USER ja existe"
@@ -43,7 +60,10 @@ main() {
 
     # Cria banco de dados padrao
     if ! sudo -u postgres psql -lqt | cut -d \| -f 1 | grep -qw "$USER"; then
-        createdb "$USER"
+        if ! createdb "$USER" >> "$LOG_FILE" 2>&1; then
+            fail "Falha ao criar banco de dados. Verifique o log: $LOG_FILE"
+            return 1
+        fi
         ok "Banco de dados padrao criado: $USER"
     else
         ok "Banco de dados $USER ja existe"

--- a/scripts-fedora/assets/install-ruby.sh
+++ b/scripts-fedora/assets/install-ruby.sh
@@ -12,8 +12,8 @@ main() {
     fi
 
     if ! command -v asdf &>/dev/null; then
-        fail "asdf nao esta instalado. Por favor, execute install-asdf.sh primeiro."
-        exit 1
+        warn "asdf nao esta instalado. Execute install-asdf.sh se quiser instalar Ruby via asdf."
+        return 0
     fi
 
     # Instala dependencias de build do Ruby (Fedora)

--- a/scripts-fedora/assets/install-vulkan-stack.sh
+++ b/scripts-fedora/assets/install-vulkan-stack.sh
@@ -10,12 +10,13 @@ main() {
         "vulkan-loader"
         "vulkan-tools"
         "vulkan-validation-layers"
-        "vkd3d"
     )
 
     for pkg in "${packages[@]}"; do
         ensure_package "$pkg"
     done
+
+    ensure_package "vkd3d" || warn "vkd3d nao encontrado nos repos (opcional)."
 
     ok "Vulkan stack instalada."
 }

--- a/scripts-fedora/assets/install-yazi-deps.sh
+++ b/scripts-fedora/assets/install-yazi-deps.sh
@@ -6,6 +6,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/../lib/utils.sh"
 main() {
     info "Instalando dependencias para Yazi"
 
+    ensure_rpmfusion
+
     packages=(
         "ffmpeg"
         "p7zip"


### PR DESCRIPTION
### Motivation

- Make Fedora installation scripts more resilient so runs do not fail when packages or configs already exist. 
- Provide safer initialization and logging for services (PostgreSQL) and non-fatal fallbacks for optional desktop or runtime components. 
- Add helper installers for Rust/Cargo and npm global packages to provide reliable fallbacks when DNF lacks binaries.

### Description

- Short-circuit PostgreSQL installation by checking `rpm -q postgresql postgresql-server postgresql-contrib` and returning early if already installed, and harden init/start/create steps using `postgresql-setup` and `systemctl` with redirected logs to `LOG_FILE` and proper error handling. 
- Add `ensure_cargo_package` and `ensure_npm_global` helper functions to `scripts-fedora/lib/utils.sh` and tighten `ensure_group` to use `dnf group list --installed --ids`. 
- Make several package/install changes across installer scripts: switch `install-eza.sh` to use `ensure_cargo_package`, install `prettier` via `ensure_npm_global` in `install-lsps.sh`, call `ensure_rpmfusion` before installing `ffmpeg` in `install-yazi-deps.sh`, and treat `vkd3d` and several lib32 packages as optional with warnings. 
- Make desktop/config steps non-fatal by skipping `install-hyprland-overrides.sh` and `install-hyprland-autostart.sh` when expected files are missing, update DNF group name to `development-tools` in `install-dev-tools.sh`, and make `install-ruby.sh` return early (non-fatal) when `asdf` is not present. 

### Testing

- No automated tests were run for these script-only edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69872be4380483308b85bfb5c16e8244)