### PR TITLE
Add Charm Gum TUI support and align Arch install steps with Fedora

### DIFF
--- a/scripts-arch/assets/install-dev-tools.sh
+++ b/scripts-arch/assets/install-dev-tools.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/utils.sh"
+
+main() {
+    info "Instalando ferramentas de desenvolvimento (equivalente ao base-devel)"
+    ensure_package "base-devel"
+    ensure_package "gcc"
+    ensure_package "make"
+    ensure_package "automake"
+    ensure_package "autoconf"
+    ensure_package "pkgconf"
+}
+
+main "$@"

--- a/scripts-arch/assets/install-gum.sh
+++ b/scripts-arch/assets/install-gum.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/utils.sh"
+
+main() {
+    info "Instalando Charm Gum (TUI toolkit)"
+    ensure_package "gum"
+}
+
+main "$@"

--- a/scripts-arch/install-all.sh
+++ b/scripts-arch/install-all.sh
@@ -40,18 +40,31 @@ run_step() {
     info ">>> Executando módulo: $script"
 
     local exit_code=0
+    local spinner_title="Executando módulo: $script"
 
     if [[ $requires_root -eq 1 ]]; then
         # Se requer root, usamos sudo E passamos a variável LOG_FILE adiante
         # (Sem isso, o script filho não consegue escrever no log)
-        if sudo LOG_FILE="$LOG_FILE" "$path"; then
+        if [[ ${GUM_AVAILABLE:-0} -eq 1 ]]; then
+            if gum spin --spinner dot --title "$spinner_title" -- sudo LOG_FILE="$LOG_FILE" "$path"; then
+                exit_code=0
+            else
+                exit_code=1
+            fi
+        elif sudo LOG_FILE="$LOG_FILE" "$path"; then
             exit_code=0
         else
             exit_code=1
         fi
     else
         # Se não requer root (ex: dotfiles, stow), roda como seu usuário normal
-        if "$path"; then
+        if [[ ${GUM_AVAILABLE:-0} -eq 1 ]]; then
+            if gum spin --spinner dot --title "$spinner_title" -- "$path"; then
+                exit_code=0
+            else
+                exit_code=1
+            fi
+        elif "$path"; then
             exit_code=0
         else
             exit_code=1
@@ -71,10 +84,13 @@ STEPS=(
     # ----------------------------------------
     # 1. System Base & Core Utilities
     # ----------------------------------------
+    "install-gum.sh"
     "install-base-devel.sh"
+    "install-dev-tools.sh"
     "install-git.sh"
     "install-stow.sh"
     "install-yay.sh" # AUR helper (needed early for AUR packages)
+    "install-curl.sh"
     "install-unzip.sh"
     "install-jq.sh"
     "install-eza.sh"
@@ -105,6 +121,7 @@ STEPS=(
     # ----------------------------------------
     "install-alacritty.sh"
     "install-kitty.sh"
+    "install-ghostty.sh"
     "install-tmux.sh"
     "install-zsh-env.sh"
     "install-ohmybash-starship.sh"
@@ -135,6 +152,8 @@ STEPS=(
     "install-npm-global.sh"
     "install-lsps.sh"
     "install-vscode.sh"
+    "install-lazygit.sh"
+    "install-emacs.sh"
     "configure-git.sh" # Configuration, depends on git
 
     # ----------------------------------------

--- a/scripts-arch/lib/utils.sh
+++ b/scripts-arch/lib/utils.sh
@@ -11,6 +11,13 @@ YELLOW='\e[33m'
 RED='\e[31m'
 RESET='\e[0m'
 
+# TUI (Charm Gum)
+GUM_AVAILABLE=0
+if command -v gum >/dev/null 2>&1; then
+    GUM_AVAILABLE=1
+fi
+export GUM_AVAILABLE
+
 # Função de Log Interna (Escreve no arquivo e na tela)
 _log() {
     local level="$1"
@@ -22,8 +29,18 @@ _log() {
     # Escrita no Arquivo (Sem cores, com timestamp)
     echo "[$timestamp] [$level] $msg" >> "$LOG_FILE"
 
-    # Escrita na Tela (Com cores)
-    printf "${color}[%s] %s${RESET}\n" "$level" "$msg" >&2
+    # Escrita na Tela (Com cores ou TUI)
+    if [[ $GUM_AVAILABLE -eq 1 ]]; then
+        local gum_level="info"
+        case "$level" in
+            WARN) gum_level="warn" ;;
+            FAIL) gum_level="error" ;;
+            *) gum_level="info" ;;
+        esac
+        gum log --level "$gum_level" -- "[$level] $msg" >&2
+    else
+        printf "${color}[%s] %s${RESET}\n" "$level" "$msg" >&2
+    fi
 }
 
 info() { _log "INFO" "$BLUE" "$*"; }

--- a/scripts-fedora/assets/install-gum.sh
+++ b/scripts-fedora/assets/install-gum.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/utils.sh"
+
+main() {
+    info "Instalando Charm Gum (TUI toolkit)"
+    ensure_package "gum"
+}
+
+main "$@"

--- a/scripts-fedora/install-all.sh
+++ b/scripts-fedora/install-all.sh
@@ -41,15 +41,28 @@ run_step() {
     info ">>> Executando modulo: $script"
 
     local exit_code=0
+    local spinner_title="Executando modulo: $script"
 
     if [[ $requires_root -eq 1 ]]; then
-        if sudo LOG_FILE="$LOG_FILE" "$path"; then
+        if [[ ${GUM_AVAILABLE:-0} -eq 1 ]]; then
+            if gum spin --spinner dot --title "$spinner_title" -- sudo LOG_FILE="$LOG_FILE" "$path"; then
+                exit_code=0
+            else
+                exit_code=1
+            fi
+        elif sudo LOG_FILE="$LOG_FILE" "$path"; then
             exit_code=0
         else
             exit_code=1
         fi
     else
-        if "$path"; then
+        if [[ ${GUM_AVAILABLE:-0} -eq 1 ]]; then
+            if gum spin --spinner dot --title "$spinner_title" -- "$path"; then
+                exit_code=0
+            else
+                exit_code=1
+            fi
+        elif "$path"; then
             exit_code=0
         else
             exit_code=1
@@ -69,6 +82,7 @@ STEPS=(
     # ----------------------------------------
     # 1. System Base & Core Utilities
     # ----------------------------------------
+    "install-gum.sh"
     "install-dev-tools.sh"
     "install-git.sh"
     "install-stow.sh"

--- a/scripts-fedora/lib/utils.sh
+++ b/scripts-fedora/lib/utils.sh
@@ -12,6 +12,13 @@ YELLOW='\e[33m'
 RED='\e[31m'
 RESET='\e[0m'
 
+# TUI (Charm Gum)
+GUM_AVAILABLE=0
+if command -v gum >/dev/null 2>&1; then
+    GUM_AVAILABLE=1
+fi
+export GUM_AVAILABLE
+
 # Funcao de Log Interna (Escreve no arquivo e na tela)
 _log() {
     local level="$1"
@@ -23,8 +30,18 @@ _log() {
     # Escrita no Arquivo (Sem cores, com timestamp)
     echo "[$timestamp] [$level] $msg" >> "$LOG_FILE"
 
-    # Escrita na Tela (Com cores)
-    printf "${color}[%s] %s${RESET}\n" "$level" "$msg" >&2
+    # Escrita na Tela (Com cores ou TUI)
+    if [[ $GUM_AVAILABLE -eq 1 ]]; then
+        local gum_level="info"
+        case "$level" in
+            WARN) gum_level="warn" ;;
+            FAIL) gum_level="error" ;;
+            *) gum_level="info" ;;
+        esac
+        gum log --level "$gum_level" -- "[$level] $msg" >&2
+    else
+        printf "${color}[%s] %s${RESET}\n" "$level" "$msg" >&2
+    fi
 }
 
 info() { _log "INFO" "$BLUE" "$*"; }


### PR DESCRIPTION
### Motivation
- Migrate and align installation flows from Fedora to Arch while preserving existing Arch packages and adding missing Fedora packages to Arch.
- Improve user experience by providing a TUI-friendly output and progress spinners using Charm Gum (`gum`) when available.

### Description
- Add `gum` detection and TUI logging in `lib/utils.sh` for both Arch and Fedora so `info`/`warn`/`fail` output uses `gum log` when available.
- Use `gum spin` as a spinner wrapper in `install-all.sh` for Arch and Fedora, falling back to the original execution when `gum` is absent.
- Add installer modules `assets/install-gum.sh` for both distros and `assets/install-dev-tools.sh` for Arch, and add `install-gum.sh` to the top of the install `STEPS`.
- Align Arch install order with Fedora by adding `install-dev-tools.sh`, `install-curl.sh`, `install-ghostty.sh`, `install-lazygit.sh`, and `install-emacs.sh` to the Arch `install-all.sh` `STEPS` without removing existing Arch packages.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875ca889688330910e9a18505dfe4a)